### PR TITLE
Add Windows port (C# WinForms tray app)

### DIFF
--- a/windows/.gitignore
+++ b/windows/.gitignore
@@ -1,0 +1,3 @@
+WhisperApp.exe
+*.pdb
+selftest.txt

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,0 +1,67 @@
+# WhisperApp for Windows
+
+พอร์ตของ [WhisperApp](https://github.com/Gamezxz/WhisperApp) (macOS) มาเป็นแอป Windows แบบ system tray —
+**กดปุ่มลัดค้างแล้วพูด ปล่อยปุ่ม ข้อความจะพิมพ์ลงแอปที่ใช้อยู่ให้อัตโนมัติ** (สไตล์ Wispr Flow)
+
+พูด → ถอดเสียง (Groq / OpenAI / ElevenLabs / whisper.cpp ในเครื่อง) → AI เกลาข้อความ (แก้คำผิด เว้นวรรค วรรคตอน) → วางลงแอปที่โฟกัสอยู่ผ่าน Ctrl+V
+
+## เริ่มใช้งาน
+
+1. ดับเบิลคลิก `run.bat` (build อัตโนมัติครั้งแรก แล้วเปิดแอปเป็นไอคอนไมค์ที่ tray)
+2. ครั้งแรกหน้าตั้งค่าจะเปิดเอง → ใส่ API key
+   - แนะนำ **Groq** (ฟรี, เร็ว): คีย์เดียวใช้ได้ทั้งถอดเสียง + เกลาข้อความ — สมัครที่ console.groq.com
+3. เปิดแอปไหนก็ได้ คลิกช่องพิมพ์ → **กด F9 ค้างไว้ พูด แล้วปล่อย** → ข้อความพิมพ์ให้เอง
+
+> ถ้า auto-paste ไม่ทำงาน ข้อความจะอยู่ใน clipboard เสมอ — กด Ctrl+V เองได้เลย
+
+## ปุ่มลัด
+
+- ค่าเริ่มต้น: **กด F9 ค้างเพื่อพูด** (push-to-talk) — ปล่อยแล้วเริ่มถอดเสียงทันที
+- เปลี่ยนปุ่ม (F1–F12, CapsLock, Right Ctrl, Space ฯลฯ + Ctrl/Alt/Shift) และสลับเป็นโหมด
+  กดครั้งแรกเริ่ม/กดอีกครั้งหยุด ได้ในหน้าตั้งค่า
+- ปุ่มลัดถูก "กลืน" ไว้ ไม่พิมพ์ลงแอปที่ใช้งานอยู่
+
+## ผู้ให้บริการที่รองรับ (เหมือนเวอร์ชัน macOS)
+
+| | ตัวเลือก |
+|---|---|
+| ถอดเสียง (STT) | Groq Whisper (ค่าเริ่มต้น) · OpenAI · ElevenLabs Scribe · endpoint ใดๆ ที่เข้ากับ OpenAI · whisper.cpp ในเครื่อง (ออฟไลน์) |
+| เกลาข้อความ (LLM) | Groq (ค่าเริ่มต้น) · DeepSeek · OpenAI · OpenRouter · Gemini · Anthropic Claude · GLM (Z.AI) · custom |
+
+API key ใส่ในหน้าตั้งค่า หรือใช้จาก environment variable เดิมก็ได้ (`GROQ_API_KEY`, `OPENAI_API_KEY`,
+`ELEVENLABS_API_KEY`, `DEEPSEEK_API_KEY`, `ANTHROPIC_API_KEY`, …) — ค่าที่ใส่ในแอปจะ override env
+
+การตั้งค่าทั้งหมดเก็บที่ `%APPDATA%\WhisperApp\config.json` (log อยู่ที่ `app.log` ข้างกัน)
+
+## whisper.cpp ในเครื่อง (ออฟไลน์ — ไม่บังคับ)
+
+1. โหลด whisper.cpp binary ของ Windows (`whisper-cli.exe`) วางที่ `%USERPROFILE%\.whisper-models\` (หรือใน PATH)
+2. โหลดโมเดล `ggml-*.bin` ใส่โฟลเดอร์เดียวกัน (แอปเลือกตัวที่แม่นสุดให้เอง: large-v3 > medium > … > tiny)
+3. ติ๊ก "ใช้ whisper.cpp ในเครื่องแทน cloud" ในหน้าตั้งค่า
+
+## การ build
+
+ไม่ต้องติดตั้งอะไรเพิ่ม — ใช้ .NET Framework 4.8 ที่มากับ Windows 10/11 และคอมไพเลอร์ Roslyn
+จาก VS 2019 Build Tools (fallback เป็น csc ของ .NET Framework):
+
+```bat
+build.bat        รี่คอมไพล์ → WhisperApp.exe (ไฟล์เดียว ไม่มี dependency)
+run.bat          build ถ้ายังไม่มี exe แล้วเปิดแอป
+WhisperApp.exe --selftest [out.txt]   ทดสอบไมค์/config แบบไม่มี UI
+```
+
+เปิดติดเครื่องอัตโนมัติ: ติ๊ก "เริ่มพร้อม Windows" ในหน้าตั้งค่าหรือเมนู tray (เขียน HKCU Run key)
+
+## แก้ปัญหา
+
+- **ไม่พบไมโครโฟน** — เช็คสาย/เลือก default input ใน Sound settings และ Settings > Privacy > Microphone
+  ต้องเปิด "Let desktop apps access your microphone"
+- **paste ไม่ลงแอปที่รันแบบ Administrator** — Windows บล็อกการส่งคีย์ข้ามระดับสิทธิ์
+  ให้รัน WhisperApp แบบ admin ด้วย หรือกด Ctrl+V เอง (ข้อความอยู่ใน clipboard แล้ว)
+- **ถอดเสียงช้า/error** — ดู `%APPDATA%\WhisperApp\app.log` (เมนู tray → เปิดโฟลเดอร์ข้อมูล)
+
+## ต่างจากเวอร์ชัน macOS ตรงไหน
+
+- ปุ่มลัดเริ่มต้นเป็น **F9** (Windows ไม่เปิดปุ่ม Fn ให้แอปอ่านเหมือน macOS)
+- โหมด toggle ไม่ต้องเคาะ 2 ครั้งตอนเริ่ม (ปุ่มลัดถูกกลืน ไม่รบกวนแอปอื่น จึงไม่จำเป็น)
+- ไม่ต้องขอสิทธิ์ Accessibility — Windows ให้จำลอง Ctrl+V ได้เลย

--- a/windows/build.bat
+++ b/windows/build.bat
@@ -1,0 +1,18 @@
+@echo off
+rem Build WhisperApp for Windows - no SDK needed, uses the Roslyn compiler
+rem bundled with VS 2019 Build Tools (falls back to the .NET Framework compiler).
+setlocal
+
+set "CSC=C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn\csc.exe"
+if not exist "%CSC%" set "CSC=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\Roslyn\csc.exe"
+if not exist "%CSC%" set "CSC=C:\Windows\Microsoft.NET\Framework64\v4.0.30319\csc.exe"
+
+set "FW=C:\Windows\Microsoft.NET\Framework64\v4.0.30319"
+
+"%CSC%" /nologo /noconfig /nostdlib+ /target:winexe /platform:anycpu /optimize+ /langversion:7.3 /codepage:65001 /out:"%~dp0WhisperApp.exe" /r:"%FW%\mscorlib.dll" /r:"%FW%\System.dll" /r:"%FW%\System.Core.dll" /r:"%FW%\System.Drawing.dll" /r:"%FW%\System.Windows.Forms.dll" /r:"%FW%\System.Net.Http.dll" /r:"%FW%\System.Web.Extensions.dll" "%~dp0src\*.cs"
+
+if errorlevel 1 (
+  echo BUILD FAILED
+  exit /b 1
+)
+echo BUILD OK: %~dp0WhisperApp.exe

--- a/windows/run.bat
+++ b/windows/run.bat
@@ -1,0 +1,7 @@
+@echo off
+rem Build (if needed) and launch WhisperApp
+if not exist "%~dp0WhisperApp.exe" (
+  call "%~dp0build.bat"
+  if errorlevel 1 exit /b 1
+)
+start "" "%~dp0WhisperApp.exe"

--- a/windows/src/AudioRecorder.cs
+++ b/windows/src/AudioRecorder.cs
@@ -1,0 +1,303 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace WhisperWin
+{
+    /// Records microphone audio to a 16 kHz mono 16-bit WAV file (the format Whisper expects)
+    /// using the winmm waveIn API. Exposes a live RMS level (0..1) for the waveform overlay.
+    public class AudioRecorder
+    {
+        private const int SampleRate = 16000;
+        private const int BufferMs = 100;
+        private const int BufferBytes = SampleRate * 2 * BufferMs / 1000; // 3200
+        private const int BufferCount = 8;
+        private const uint WaveMapper = 0xFFFFFFFF;
+        private const int WhdrDone = 0x00000001;
+
+        private IntPtr _hWaveIn = IntPtr.Zero;
+        private IntPtr[] _headers = new IntPtr[BufferCount];
+        private IntPtr[] _buffers = new IntPtr[BufferCount];
+        private MemoryStream _pcm;
+        private Thread _pollThread;
+        private volatile bool _running;
+        private int _headerSize;
+        private int _flagsOffset;
+        private int _bytesOffset;
+        private readonly object _gate = new object();
+
+        public bool IsRecording { get; private set; }
+        public float Level { get; private set; }   // 0..1, updated while recording
+
+        /// Starts capture. Returns false if no microphone / device error.
+        public bool Start()
+        {
+            lock (_gate)
+            {
+                if (IsRecording) return true;
+
+                var fmt = new WAVEFORMATEX
+                {
+                    wFormatTag = 1, // PCM
+                    nChannels = 1,
+                    nSamplesPerSec = SampleRate,
+                    wBitsPerSample = 16,
+                    nBlockAlign = 2,
+                    nAvgBytesPerSec = SampleRate * 2,
+                    cbSize = 0,
+                };
+
+                int rc = waveInOpen(out _hWaveIn, WaveMapper, ref fmt, IntPtr.Zero, IntPtr.Zero, 0);
+                if (rc != 0)
+                {
+                    Log.Error("waveInOpen failed rc=" + rc + " (no microphone?)");
+                    _hWaveIn = IntPtr.Zero;
+                    return false;
+                }
+
+                _headerSize = Marshal.SizeOf(typeof(WAVEHDR));
+                _flagsOffset = (int)Marshal.OffsetOf(typeof(WAVEHDR), "dwFlags");
+                _bytesOffset = (int)Marshal.OffsetOf(typeof(WAVEHDR), "dwBytesRecorded");
+                _pcm = new MemoryStream();
+
+                for (int i = 0; i < BufferCount; i++)
+                {
+                    _buffers[i] = Marshal.AllocHGlobal(BufferBytes);
+                    _headers[i] = Marshal.AllocHGlobal(_headerSize);
+                    PrepareAndAdd(i);
+                }
+
+                rc = waveInStart(_hWaveIn);
+                if (rc != 0)
+                {
+                    Log.Error("waveInStart failed rc=" + rc);
+                    CleanupNative();
+                    return false;
+                }
+
+                IsRecording = true;
+                _running = true;
+                _pollThread = new Thread(PollLoop) { IsBackground = true, Name = "waveIn-poll" };
+                _pollThread.Start();
+                Log.Info("Recording started");
+                return true;
+            }
+        }
+
+        /// Stops capture and writes the WAV file. Returns null if nothing was recorded.
+        public string Stop()
+        {
+            Thread poll = null;
+            lock (_gate)
+            {
+                if (!IsRecording) return null;
+                IsRecording = false;
+                _running = false;
+                poll = _pollThread;
+                _pollThread = null;
+            }
+
+            if (poll != null) poll.Join(500);
+
+            byte[] data;
+            lock (_gate)
+            {
+                if (_hWaveIn != IntPtr.Zero)
+                {
+                    waveInStop(_hWaveIn);
+                    waveInReset(_hWaveIn); // marks all pending buffers done
+                    DrainDoneBuffers();
+                }
+                data = _pcm != null ? _pcm.ToArray() : new byte[0];
+                CleanupNative();
+                Level = 0;
+            }
+
+            if (data.Length == 0) return null;
+
+            var path = Path.Combine(Path.GetTempPath(), "whisper_" + Guid.NewGuid().ToString("N") + ".wav");
+            try
+            {
+                WriteWav(path, data);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("WAV write: " + ex.Message);
+                return null;
+            }
+            Log.Info("Recording stopped → " + path + " (" + data.Length + " bytes, " +
+                     (data.Length / (double)(SampleRate * 2)).ToString("0.00") + "s)");
+            return path;
+        }
+
+        public double RecordedSeconds
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _pcm == null ? 0 : _pcm.Length / (double)(SampleRate * 2);
+                }
+            }
+        }
+
+        // ---------- internals ----------
+
+        private void PrepareAndAdd(int i)
+        {
+            var hdr = new WAVEHDR
+            {
+                lpData = _buffers[i],
+                dwBufferLength = (uint)BufferBytes,
+            };
+            Marshal.StructureToPtr(hdr, _headers[i], false);
+            waveInPrepareHeader(_hWaveIn, _headers[i], _headerSize);
+            waveInAddBuffer(_hWaveIn, _headers[i], _headerSize);
+        }
+
+        private void PollLoop()
+        {
+            int next = 0;
+            while (_running)
+            {
+                bool consumed = false;
+                lock (_gate)
+                {
+                    if (!_running || _hWaveIn == IntPtr.Zero) break;
+                    // buffers complete in the order they were added → check only the next expected one
+                    int flags = Marshal.ReadInt32(_headers[next], _flagsOffset);
+                    if ((flags & WhdrDone) != 0)
+                    {
+                        ConsumeBuffer(next);
+                        waveInUnprepareHeader(_hWaveIn, _headers[next], _headerSize);
+                        PrepareAndAdd(next);
+                        next = (next + 1) % BufferCount;
+                        consumed = true;
+                    }
+                }
+                if (!consumed) Thread.Sleep(15);
+            }
+        }
+
+        /// Copies recorded bytes from a done buffer into the PCM stream and updates Level.
+        private void ConsumeBuffer(int i)
+        {
+            int bytes = Marshal.ReadInt32(_headers[i], _bytesOffset);
+            if (bytes <= 0) return;
+            var chunk = new byte[bytes];
+            Marshal.Copy(_buffers[i], chunk, 0, bytes);
+            _pcm.Write(chunk, 0, bytes);
+
+            // RMS level for waveform display — same ×8 visibility scale as the macOS version
+            int n = bytes / 2;
+            if (n > 0)
+            {
+                double sum = 0;
+                for (int s = 0; s < n; s++)
+                {
+                    short v = (short)(chunk[s * 2] | (chunk[s * 2 + 1] << 8));
+                    double f = v / 32768.0;
+                    sum += f * f;
+                }
+                var rms = Math.Sqrt(sum / n);
+                Level = (float)Math.Min(1.0, rms * 8);
+            }
+        }
+
+        private void DrainDoneBuffers()
+        {
+            for (int i = 0; i < BufferCount; i++)
+            {
+                if (_headers[i] == IntPtr.Zero) continue;
+                int flags = Marshal.ReadInt32(_headers[i], _flagsOffset);
+                if ((flags & WhdrDone) != 0)
+                {
+                    ConsumeBuffer(i);
+                    waveInUnprepareHeader(_hWaveIn, _headers[i], _headerSize);
+                }
+            }
+        }
+
+        private void CleanupNative()
+        {
+            if (_hWaveIn != IntPtr.Zero)
+            {
+                waveInClose(_hWaveIn);
+                _hWaveIn = IntPtr.Zero;
+            }
+            for (int i = 0; i < BufferCount; i++)
+            {
+                if (_headers[i] != IntPtr.Zero) { Marshal.FreeHGlobal(_headers[i]); _headers[i] = IntPtr.Zero; }
+                if (_buffers[i] != IntPtr.Zero) { Marshal.FreeHGlobal(_buffers[i]); _buffers[i] = IntPtr.Zero; }
+            }
+        }
+
+        private static void WriteWav(string path, byte[] pcm)
+        {
+            using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+            using (var w = new BinaryWriter(fs))
+            {
+                w.Write(new[] { 'R', 'I', 'F', 'F' });
+                w.Write(36 + pcm.Length);
+                w.Write(new[] { 'W', 'A', 'V', 'E' });
+                w.Write(new[] { 'f', 'm', 't', ' ' });
+                w.Write(16);                 // fmt chunk size
+                w.Write((short)1);           // PCM
+                w.Write((short)1);           // mono
+                w.Write(SampleRate);
+                w.Write(SampleRate * 2);     // byte rate
+                w.Write((short)2);           // block align
+                w.Write((short)16);          // bits per sample
+                w.Write(new[] { 'd', 'a', 't', 'a' });
+                w.Write(pcm.Length);
+                w.Write(pcm);
+            }
+        }
+
+        // ---------- P/Invoke ----------
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct WAVEFORMATEX
+        {
+            public ushort wFormatTag;
+            public ushort nChannels;
+            public int nSamplesPerSec;
+            public int nAvgBytesPerSec;
+            public ushort nBlockAlign;
+            public ushort wBitsPerSample;
+            public ushort cbSize;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct WAVEHDR
+        {
+            public IntPtr lpData;
+            public uint dwBufferLength;
+            public uint dwBytesRecorded;
+            public IntPtr dwUser;
+            public uint dwFlags;
+            public uint dwLoops;
+            public IntPtr lpNext;
+            public IntPtr reserved;
+        }
+
+        [DllImport("winmm.dll")]
+        private static extern int waveInOpen(out IntPtr hWaveIn, uint deviceId, ref WAVEFORMATEX fmt,
+                                             IntPtr callback, IntPtr instance, int flags);
+        [DllImport("winmm.dll")]
+        private static extern int waveInPrepareHeader(IntPtr hWaveIn, IntPtr header, int size);
+        [DllImport("winmm.dll")]
+        private static extern int waveInUnprepareHeader(IntPtr hWaveIn, IntPtr header, int size);
+        [DllImport("winmm.dll")]
+        private static extern int waveInAddBuffer(IntPtr hWaveIn, IntPtr header, int size);
+        [DllImport("winmm.dll")]
+        private static extern int waveInStart(IntPtr hWaveIn);
+        [DllImport("winmm.dll")]
+        private static extern int waveInStop(IntPtr hWaveIn);
+        [DllImport("winmm.dll")]
+        private static extern int waveInReset(IntPtr hWaveIn);
+        [DllImport("winmm.dll")]
+        private static extern int waveInClose(IntPtr hWaveIn);
+    }
+}

--- a/windows/src/Config.cs
+++ b/windows/src/Config.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Web.Script.Serialization;
+
+namespace WhisperWin
+{
+    /// App settings persisted as JSON at %APPDATA%\WhisperApp\config.json
+    /// API key resolution order matches macOS version: saved value → environment variable
+    public class AppConfig
+    {
+        public string SttProvider = "groq";
+        public Dictionary<string, string> SttKeys = new Dictionary<string, string>();
+        public Dictionary<string, string> SttModels = new Dictionary<string, string>();
+        public Dictionary<string, string> SttEndpoints = new Dictionary<string, string>();
+
+        public string LlmProvider = "groq";
+        public Dictionary<string, string> LlmKeys = new Dictionary<string, string>();
+        public Dictionary<string, string> LlmModels = new Dictionary<string, string>();
+        public Dictionary<string, string> LlmEndpoints = new Dictionary<string, string>();
+
+        public string Language = "th";          // th | en | auto
+        public bool UseCorrection = true;
+        public bool UseCloudStt = true;
+
+        public int HotkeyVk = 0x78;             // F9
+        public bool HotkeyCtrl = false;
+        public bool HotkeyAlt = false;
+        public bool HotkeyShift = false;
+        public bool HotkeyHoldMode = true;      // true = push-to-talk, false = toggle
+
+        public string LocalWhisperExe = "";     // path to whisper-cli.exe (optional)
+        public string LocalWhisperModelDir = ""; // dir containing ggml-*.bin (optional)
+
+        // ---------- persistence ----------
+
+        public static string Dir
+        {
+            get { return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "WhisperApp"); }
+        }
+
+        public static string FilePath
+        {
+            get { return Path.Combine(Dir, "config.json"); }
+        }
+
+        public static AppConfig Load()
+        {
+            try
+            {
+                if (File.Exists(FilePath))
+                {
+                    var json = File.ReadAllText(FilePath);
+                    var ser = new JavaScriptSerializer { MaxJsonLength = 8 * 1024 * 1024 };
+                    var cfg = ser.Deserialize<AppConfig>(json);
+                    if (cfg != null) { cfg.EnsureDicts(); return cfg; }
+                }
+            }
+            catch (Exception ex) { Log.Error("Config load: " + ex.Message); }
+            var fresh = new AppConfig();
+            fresh.EnsureDicts();
+            return fresh;
+        }
+
+        public void Save()
+        {
+            try
+            {
+                Directory.CreateDirectory(Dir);
+                var ser = new JavaScriptSerializer { MaxJsonLength = 8 * 1024 * 1024 };
+                File.WriteAllText(FilePath, ser.Serialize(this));
+            }
+            catch (Exception ex) { Log.Error("Config save: " + ex.Message); }
+        }
+
+        private void EnsureDicts()
+        {
+            if (SttKeys == null) SttKeys = new Dictionary<string, string>();
+            if (SttModels == null) SttModels = new Dictionary<string, string>();
+            if (SttEndpoints == null) SttEndpoints = new Dictionary<string, string>();
+            if (LlmKeys == null) LlmKeys = new Dictionary<string, string>();
+            if (LlmModels == null) LlmModels = new Dictionary<string, string>();
+            if (LlmEndpoints == null) LlmEndpoints = new Dictionary<string, string>();
+        }
+
+        // ---------- resolution helpers (saved value → env var → default) ----------
+
+        private static string FromDict(Dictionary<string, string> d, string key)
+        {
+            string v;
+            if (d != null && d.TryGetValue(key, out v) && !string.IsNullOrWhiteSpace(v)) return v.Trim();
+            return null;
+        }
+
+        public string SttKey(SttProvider p)
+        {
+            return FromDict(SttKeys, p.Id) ?? EnvOrNull(p.EnvKey);
+        }
+
+        public string SttModel(SttProvider p)
+        {
+            return FromDict(SttModels, p.Id) ?? p.DefaultModel;
+        }
+
+        public string SttEndpoint(SttProvider p)
+        {
+            return FromDict(SttEndpoints, p.Id) ?? p.DefaultEndpoint;
+        }
+
+        public string LlmKey(LlmProvider p)
+        {
+            return FromDict(LlmKeys, p.Id) ?? EnvOrNull(p.EnvKey);
+        }
+
+        public string LlmModel(LlmProvider p)
+        {
+            return FromDict(LlmModels, p.Id) ?? p.DefaultModel;
+        }
+
+        public string LlmEndpoint(LlmProvider p)
+        {
+            return FromDict(LlmEndpoints, p.Id) ?? p.DefaultEndpoint;
+        }
+
+        public bool SttConfigured()
+        {
+            var p = SttRegistry.Get(SttProvider);
+            return !string.IsNullOrEmpty(SttKey(p)) && !string.IsNullOrEmpty(SttEndpoint(p));
+        }
+
+        public bool LlmConfigured()
+        {
+            var p = LlmRegistry.Get(LlmProvider);
+            return !string.IsNullOrEmpty(LlmKey(p)) && !string.IsNullOrEmpty(LlmEndpoint(p));
+        }
+
+        private static string EnvOrNull(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return null;
+            var v = Environment.GetEnvironmentVariable(name);
+            return string.IsNullOrWhiteSpace(v) ? null : v.Trim();
+        }
+    }
+
+    /// Minimal file logger at %APPDATA%\WhisperApp\app.log
+    public static class Log
+    {
+        private static readonly object Gate = new object();
+
+        public static string LogPath
+        {
+            get { return Path.Combine(AppConfig.Dir, "app.log"); }
+        }
+
+        public static void Info(string msg) { WriteLine("INFO  " + msg); }
+        public static void Error(string msg) { WriteLine("ERROR " + msg); }
+
+        private static void WriteLine(string msg)
+        {
+            try
+            {
+                lock (Gate)
+                {
+                    Directory.CreateDirectory(AppConfig.Dir);
+                    File.AppendAllText(LogPath,
+                        DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") + "  " + msg + Environment.NewLine);
+                }
+            }
+            catch { }
+        }
+    }
+}

--- a/windows/src/DictationController.cs
+++ b/windows/src/DictationController.cs
@@ -1,0 +1,147 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace WhisperWin
+{
+    /// Orchestrates everything: record → transcribe (cloud/local) → correct (LLM) → paste.
+    /// All public members must be called on the UI thread; async continuations return to it
+    /// via the WinForms SynchronizationContext.
+    public class DictationController
+    {
+        private readonly AppConfig _cfg;
+        private readonly AudioRecorder _recorder = new AudioRecorder();
+        private readonly Overlay _overlay;
+        private readonly System.Windows.Forms.Timer _levelTimer;
+        private bool _processing;
+        private int _gen; // stage generation — cancels stale auto-idle resets
+
+        public event Action<Stage> StageChanged;
+
+        public bool IsRecording { get { return _recorder.IsRecording; } }
+
+        public DictationController(AppConfig cfg, Overlay overlay)
+        {
+            _cfg = cfg;
+            _overlay = overlay;
+            _levelTimer = new System.Windows.Forms.Timer { Interval = 50 };
+            _levelTimer.Tick += delegate { _overlay.Level = _recorder.Level; };
+        }
+
+        public void Toggle()
+        {
+            if (_recorder.IsRecording) StopAndProcess();
+            else Start();
+        }
+
+        public void Start()
+        {
+            if (_processing || _recorder.IsRecording) return;
+
+            if (_recorder.Start())
+            {
+                _levelTimer.Start();
+                SetStage(Stage.Recording, "กำลังฟัง…");
+            }
+            else
+            {
+                SetStage(Stage.Error, "ไม่พบไมโครโฟน — เช็คการเชื่อมต่อ/สิทธิ์ไมค์");
+                AutoIdle(2500);
+            }
+        }
+
+        public void StopAndProcess()
+        {
+            if (!_recorder.IsRecording) return;
+            _levelTimer.Stop();
+
+            var seconds = _recorder.RecordedSeconds;
+            var path = _recorder.Stop();
+
+            if (path == null || seconds < 0.15)
+            {
+                if (path != null) TryDelete(path);
+                SetStage(Stage.Idle, "");
+                return;
+            }
+
+            Process(path);
+        }
+
+        private async void Process(string wavPath)
+        {
+            _processing = true;
+            SetStage(Stage.Transcribing, _cfg.UseCloudStt ? "กำลังถอดเสียง…" : "กำลังถอดเสียง (เครื่องนี้)…");
+
+            string raw = null;
+            string error = null;
+            try
+            {
+                if (_cfg.UseCloudStt)
+                    raw = await SttClient.TranscribeAsync(_cfg, wavPath, _cfg.Language);
+                else
+                    raw = await LocalWhisper.TranscribeAsync(_cfg, wavPath, _cfg.Language);
+            }
+            catch (Exception ex)
+            {
+                error = ex is InvalidOperationException ? ex.Message : "เชื่อมต่อไม่สำเร็จ: " + ex.Message;
+                Log.Error("STT: " + ex);
+            }
+            finally
+            {
+                TryDelete(wavPath);
+            }
+
+            if (error != null)
+            {
+                _processing = false;
+                SetStage(Stage.Error, error);
+                AutoIdle(3000);
+                return;
+            }
+
+            var text = TextCleaner.StripSoundAnnotations(raw ?? "");
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                _processing = false;
+                SetStage(Stage.Error, "ไม่ได้ยินเสียงพูด");
+                AutoIdle(1800);
+                return;
+            }
+
+            if (_cfg.UseCorrection && _cfg.LlmConfigured())
+            {
+                SetStage(Stage.Correcting, "AI กำลังเกลาข้อความ…");
+                var corrected = await LlmClient.CorrectAsync(_cfg, text, _cfg.Language);
+                if (corrected != null) text = corrected;
+            }
+
+            Paster.Paste(text); // on UI thread — clipboard needs STA
+
+            var snippet = text.Length <= 28 ? text : text.Substring(0, 28) + "…";
+            _processing = false;
+            SetStage(Stage.Done, "✓ " + snippet);
+            AutoIdle(1500);
+        }
+
+        private void SetStage(Stage stage, string text)
+        {
+            _gen++;
+            _overlay.SetStage(stage, text);
+            var cb = StageChanged;
+            if (cb != null) cb(stage);
+        }
+
+        private async void AutoIdle(int ms)
+        {
+            int gen = _gen;
+            await Task.Delay(ms);
+            if (gen == _gen) SetStage(Stage.Idle, "");
+        }
+
+        private static void TryDelete(string path)
+        {
+            try { File.Delete(path); } catch { }
+        }
+    }
+}

--- a/windows/src/HotkeyManager.cs
+++ b/windows/src/HotkeyManager.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace WhisperWin
+{
+    /// Global hotkey via a low-level keyboard hook (works in every app, supports
+    /// hold/push-to-talk and toggle modes, and modifier keys like Right Ctrl as the hotkey).
+    /// The hotkey press is swallowed so it never types into the focused app.
+    public class HotkeyManager : IDisposable
+    {
+        private const int WH_KEYBOARD_LL = 13;
+        private const int WM_KEYDOWN = 0x0100;
+        private const int WM_KEYUP = 0x0101;
+        private const int WM_SYSKEYDOWN = 0x0104;
+        private const int WM_SYSKEYUP = 0x0105;
+        private const int LLKHF_INJECTED = 0x10;
+
+        private IntPtr _hook = IntPtr.Zero;
+        private readonly LowLevelKeyboardProc _proc; // kept alive so GC can't collect the delegate
+        private bool _keyIsDown;
+
+        public int Vk = 0x78;           // F9
+        public bool Ctrl, Alt, Shift;
+        public bool HoldMode = true;
+
+        /// hold: fires on press → start; toggle: fires on press → flip
+        public Action OnKeyDown;
+        /// hold mode only: fires on release → stop
+        public Action OnKeyUp;
+
+        private static readonly HashSet<int> ModifierVks = new HashSet<int>
+        {
+            0xA0, 0xA1, // L/R Shift
+            0xA2, 0xA3, // L/R Ctrl
+            0xA4, 0xA5, // L/R Alt
+            0x14,       // CapsLock (treated as standalone key)
+        };
+
+        public HotkeyManager()
+        {
+            _proc = HookCallback;
+        }
+
+        public void Install()
+        {
+            if (_hook != IntPtr.Zero) return;
+            using (var cur = Process.GetCurrentProcess())
+            using (var mod = cur.MainModule)
+            {
+                _hook = SetWindowsHookEx(WH_KEYBOARD_LL, _proc, GetModuleHandle(mod.ModuleName), 0);
+            }
+            if (_hook == IntPtr.Zero) Log.Error("SetWindowsHookEx failed: " + Marshal.GetLastWin32Error());
+        }
+
+        public void Uninstall()
+        {
+            if (_hook != IntPtr.Zero)
+            {
+                UnhookWindowsHookEx(_hook);
+                _hook = IntPtr.Zero;
+            }
+            _keyIsDown = false;
+        }
+
+        public void Dispose() { Uninstall(); }
+
+        public string DisplayString
+        {
+            get
+            {
+                var parts = new List<string>();
+                if (Ctrl) parts.Add("Ctrl");
+                if (Alt) parts.Add("Alt");
+                if (Shift) parts.Add("Shift");
+                parts.Add(KeyName(Vk));
+                return string.Join("+", parts);
+            }
+        }
+
+        public static string KeyName(int vk)
+        {
+            if (vk >= 0x70 && vk <= 0x7B) return "F" + (vk - 0x70 + 1);
+            switch (vk)
+            {
+                case 0x14: return "CapsLock";
+                case 0x91: return "ScrollLock";
+                case 0x13: return "Pause";
+                case 0x2D: return "Insert";
+                case 0x24: return "Home";
+                case 0x23: return "End";
+                case 0x21: return "PageUp";
+                case 0x22: return "PageDown";
+                case 0x20: return "Space";
+                case 0xA1: return "Right Shift";
+                case 0xA3: return "Right Ctrl";
+                case 0xA5: return "Right Alt";
+                default: return ((Keys)vk).ToString();
+            }
+        }
+
+        private static bool IsDown(int vk) { return (GetAsyncKeyState(vk) & 0x8000) != 0; }
+
+        private bool ModifiersMatch()
+        {
+            if (ModifierVks.Contains(Vk)) return true; // modifier-only hotkey → no extra mods required
+            const int VK_CONTROL = 0x11, VK_MENU = 0x12, VK_SHIFT = 0x10;
+            return IsDown(VK_CONTROL) == Ctrl && IsDown(VK_MENU) == Alt && IsDown(VK_SHIFT) == Shift;
+        }
+
+        private IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+        {
+            if (nCode >= 0)
+            {
+                var info = (KBDLLHOOKSTRUCT)Marshal.PtrToStructure(lParam, typeof(KBDLLHOOKSTRUCT));
+                bool injected = (info.flags & LLKHF_INJECTED) != 0;
+                int msg = (int)wParam;
+
+                if (!injected && (int)info.vkCode == Vk)
+                {
+                    if (msg == WM_KEYDOWN || msg == WM_SYSKEYDOWN)
+                    {
+                        if (_keyIsDown)
+                            return (IntPtr)1; // swallow auto-repeat while held
+
+                        if (ModifiersMatch())
+                        {
+                            _keyIsDown = true;
+                            var cb = OnKeyDown;
+                            if (cb != null) cb();
+                            return (IntPtr)1; // swallow so the key never reaches the focused app
+                        }
+                    }
+                    else if (msg == WM_KEYUP || msg == WM_SYSKEYUP)
+                    {
+                        if (_keyIsDown)
+                        {
+                            _keyIsDown = false;
+                            if (HoldMode)
+                            {
+                                var cb = OnKeyUp;
+                                if (cb != null) cb();
+                            }
+                            return (IntPtr)1;
+                        }
+                    }
+                }
+            }
+            return CallNextHookEx(_hook, nCode, wParam, lParam);
+        }
+
+        // ---------- P/Invoke ----------
+
+        private delegate IntPtr LowLevelKeyboardProc(int nCode, IntPtr wParam, IntPtr lParam);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct KBDLLHOOKSTRUCT
+        {
+            public uint vkCode;
+            public uint scanCode;
+            public uint flags;
+            public uint time;
+            public IntPtr dwExtraInfo;
+        }
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern IntPtr SetWindowsHookEx(int idHook, LowLevelKeyboardProc lpfn, IntPtr hMod, uint dwThreadId);
+
+        [DllImport("user32.dll")]
+        private static extern bool UnhookWindowsHookEx(IntPtr hhk);
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr GetModuleHandle(string lpModuleName);
+
+        [DllImport("user32.dll")]
+        private static extern short GetAsyncKeyState(int vKey);
+    }
+}

--- a/windows/src/Json.cs
+++ b/windows/src/Json.cs
@@ -1,0 +1,44 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Web.Script.Serialization;
+
+namespace WhisperWin
+{
+    /// Thin helpers over JavaScriptSerializer for navigating untyped JSON responses.
+    public static class Json
+    {
+        public static JavaScriptSerializer Serializer()
+        {
+            return new JavaScriptSerializer { MaxJsonLength = 32 * 1024 * 1024 };
+        }
+
+        public static Dictionary<string, object> ParseObject(string json)
+        {
+            try { return Serializer().Deserialize<Dictionary<string, object>>(json); }
+            catch { return null; }
+        }
+
+        public static object Get(Dictionary<string, object> obj, string key)
+        {
+            object v;
+            return obj != null && obj.TryGetValue(key, out v) ? v : null;
+        }
+
+        public static Dictionary<string, object> AsObject(object o)
+        {
+            return o as Dictionary<string, object>;
+        }
+
+        public static IEnumerable<object> AsArray(object o)
+        {
+            var e = o as IEnumerable;
+            if (e == null || o is string) yield break;
+            foreach (var item in e) yield return item;
+        }
+
+        public static string AsString(object o)
+        {
+            return o as string;
+        }
+    }
+}

--- a/windows/src/LlmClient.cs
+++ b/windows/src/LlmClient.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WhisperWin
+{
+    /// AI text correction — mirrors TextCorrectionService.swift (same system prompt).
+    public static class LlmClient
+    {
+        /// Returns corrected text, or null on any failure (caller falls back to the raw text).
+        public static async Task<string> CorrectAsync(AppConfig cfg, string text, string language)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return null;
+
+            var p = LlmRegistry.Get(cfg.LlmProvider);
+            var key = cfg.LlmKey(p);
+            if (string.IsNullOrEmpty(key))
+            {
+                Log.Error("No key for " + p.Name + " (set in Settings or env " + p.EnvKey + ")");
+                return null;
+            }
+            var endpoint = cfg.LlmEndpoint(p);
+            if (string.IsNullOrEmpty(endpoint)) return null;
+            var model = cfg.LlmModel(p);
+
+            string langHint;
+            if (language == "th") langHint = "The text is in Thai";
+            else if (language == "en") langHint = "The text is in English";
+            else langHint = "The text may be in Thai or English — keep the original language";
+
+            var systemPrompt =
+                "You are a text correction assistant for speech-to-text output, which often contains\n" +
+                "misheard words and missing punctuation.\n" +
+                "Your tasks:\n" +
+                "- Fix misheard/garbled words based on context\n" +
+                "- Add punctuation and spacing to improve readability\n" +
+                "- Do NOT add new content, summarize, translate, or change word endings/speaker gender\n" +
+                "- Return ONLY the corrected text — no explanations, no quotation marks\n" +
+                langHint;
+
+            Dictionary<string, object> body;
+            if (p.Style == LlmStyle.OpenAI)
+            {
+                body = new Dictionary<string, object>
+                {
+                    { "model", model },
+                    { "temperature", 0.2 },
+                    { "messages", new object[]
+                        {
+                            new Dictionary<string, object> { { "role", "system" }, { "content", systemPrompt } },
+                            new Dictionary<string, object> { { "role", "user" }, { "content", text } },
+                        }
+                    },
+                };
+            }
+            else
+            {
+                body = new Dictionary<string, object>
+                {
+                    { "model", model },
+                    { "max_tokens", 8192 },
+                    { "temperature", 0.2 },
+                    { "system", systemPrompt },
+                    { "messages", new object[]
+                        {
+                            new Dictionary<string, object> { { "role", "user" }, { "content", text } },
+                        }
+                    },
+                };
+                // GLM enables thinking by default → disable for fast correction (parity with macOS)
+                if (model != null && model.ToLowerInvariant().Contains("glm"))
+                    body["thinking"] = new Dictionary<string, object> { { "type", "disabled" } };
+            }
+
+            try
+            {
+                using (var req = new HttpRequestMessage(HttpMethod.Post, endpoint))
+                {
+                    if (p.Style == LlmStyle.OpenAI)
+                    {
+                        req.Headers.TryAddWithoutValidation("Authorization", "Bearer " + key);
+                    }
+                    else
+                    {
+                        req.Headers.TryAddWithoutValidation("x-api-key", key);
+                        req.Headers.TryAddWithoutValidation("anthropic-version", "2023-06-01");
+                    }
+                    req.Content = new StringContent(Json.Serializer().Serialize(body), Encoding.UTF8, "application/json");
+
+                    using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60)))
+                    using (var resp = await SttClient.Http.SendAsync(req, cts.Token).ConfigureAwait(false))
+                    {
+                        var respBody = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        if (!resp.IsSuccessStatusCode)
+                        {
+                            Log.Error(p.Name + " HTTP " + (int)resp.StatusCode + ": " + SttClient.Truncate(respBody, 500));
+                            return null;
+                        }
+
+                        var json = Json.ParseObject(respBody);
+                        var content = ExtractText(json, p.Style);
+                        if (content == null)
+                        {
+                            Log.Error(p.Name + " unexpected response: " + SttClient.Truncate(respBody, 500));
+                            return null;
+                        }
+                        var cleaned = content.Trim().Trim('"', '\'');
+                        return string.IsNullOrEmpty(cleaned) ? null : cleaned;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Correction (" + p.Name + "): " + ex.Message);
+                return null;
+            }
+        }
+
+        private static string ExtractText(Dictionary<string, object> json, LlmStyle style)
+        {
+            if (json == null) return null;
+            if (style == LlmStyle.OpenAI)
+            {
+                var choice = Json.AsObject(Json.AsArray(Json.Get(json, "choices")).FirstOrDefault());
+                var message = Json.AsObject(Json.Get(choice, "message"));
+                return Json.AsString(Json.Get(message, "content"));
+            }
+            else
+            {
+                var parts = Json.AsArray(Json.Get(json, "content"))
+                    .Select(x => Json.AsString(Json.Get(Json.AsObject(x), "text")))
+                    .Where(t => t != null);
+                var joined = string.Concat(parts);
+                return joined.Length > 0 ? joined : null;
+            }
+        }
+    }
+}

--- a/windows/src/LocalWhisper.cs
+++ b/windows/src/LocalWhisper.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace WhisperWin
+{
+    /// Offline STT via whisper.cpp (whisper-cli.exe) — mirrors WhisperService.swift.
+    /// Exe: config path → %USERPROFILE%\.whisper-models\whisper-cli.exe → PATH
+    /// Model: best .bin in %USERPROFILE%\.whisper-models (large-v3 > large > medium > small > base > tiny)
+    public static class LocalWhisper
+    {
+        public static string DefaultModelDir
+        {
+            get { return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".whisper-models"); }
+        }
+
+        public static string FindExe(AppConfig cfg)
+        {
+            if (!string.IsNullOrWhiteSpace(cfg.LocalWhisperExe) && File.Exists(cfg.LocalWhisperExe))
+                return cfg.LocalWhisperExe;
+
+            var inModels = Path.Combine(DefaultModelDir, "whisper-cli.exe");
+            if (File.Exists(inModels)) return inModels;
+
+            var paths = (Environment.GetEnvironmentVariable("PATH") ?? "").Split(';');
+            foreach (var dir in paths)
+            {
+                if (string.IsNullOrWhiteSpace(dir)) continue;
+                try
+                {
+                    var candidate = Path.Combine(dir.Trim(), "whisper-cli.exe");
+                    if (File.Exists(candidate)) return candidate;
+                }
+                catch { }
+            }
+            return null;
+        }
+
+        public static string FindModel(AppConfig cfg)
+        {
+            var dir = string.IsNullOrWhiteSpace(cfg.LocalWhisperModelDir) ? DefaultModelDir : cfg.LocalWhisperModelDir;
+            if (!Directory.Exists(dir)) return null;
+            var bins = Directory.GetFiles(dir, "*.bin");
+            if (bins.Length == 0) return null;
+
+            var priority = new[] { "large-v3", "large", "medium", "small", "base", "tiny" };
+            foreach (var key in priority)
+            {
+                var match = bins.FirstOrDefault(b => Path.GetFileName(b).Contains(key));
+                if (match != null) return match;
+            }
+            return bins[0];
+        }
+
+        public static Task<string> TranscribeAsync(AppConfig cfg, string wavPath, string language)
+        {
+            return Task.Run(() =>
+            {
+                var exe = FindExe(cfg);
+                if (exe == null)
+                    throw new InvalidOperationException("ไม่พบ whisper-cli.exe (ตั้งค่า path ใน Settings)");
+                var model = FindModel(cfg);
+                if (model == null)
+                    throw new InvalidOperationException("ไม่พบไฟล์โมเดล ggml-*.bin ใน " + DefaultModelDir);
+
+                var psi = new ProcessStartInfo
+                {
+                    FileName = exe,
+                    Arguments = "-m \"" + model + "\" -f \"" + wavPath + "\" -nt -l " + language,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                    StandardOutputEncoding = System.Text.Encoding.UTF8,
+                };
+
+                using (var proc = Process.Start(psi))
+                {
+                    var stdout = proc.StandardOutput.ReadToEnd();
+                    var stderr = proc.StandardError.ReadToEnd();
+                    proc.WaitForExit();
+
+                    if (!string.IsNullOrWhiteSpace(stderr))
+                        Log.Info("whisper stderr: " + SttClient.Truncate(stderr, 500));
+
+                    // strip ANSI color codes (ESC[...m) in case whisper outputs color
+                    var ansi = (char)27 + "\\[[0-9;]*m";
+                    var cleaned = Regex.Replace(stdout, ansi, "");
+                    var trimmed = string.Join(" ",
+                            cleaned.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                                   .Where(l => !l.StartsWith("[")))
+                        .Trim();
+                    return trimmed.Length == 0 ? null : trimmed;
+                }
+            });
+        }
+    }
+}

--- a/windows/src/Overlay.cs
+++ b/windows/src/Overlay.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Windows.Forms;
+
+namespace WhisperWin
+{
+    public enum Stage { Idle, Recording, Transcribing, Correcting, Done, Error }
+
+    /// Floating status pill at the bottom-center of the screen — never takes focus,
+    /// shows current stage + a live waveform while recording (like the macOS overlay).
+    public class Overlay : Form
+    {
+        private const int WS_EX_NOACTIVATE = 0x08000000;
+        private const int WS_EX_TOOLWINDOW = 0x00000080;
+
+        private Stage _stage = Stage.Idle;
+        private string _text = "";
+        private readonly float[] _bars = new float[28];
+        private readonly Timer _anim;
+        private readonly Font _font = new Font("Segoe UI", 10.5f, FontStyle.Regular);
+
+        /// Live input level 0..1 — set by the controller while recording.
+        public float Level { get; set; }
+
+        public Overlay()
+        {
+            FormBorderStyle = FormBorderStyle.None;
+            ShowInTaskbar = false;
+            TopMost = true;
+            StartPosition = FormStartPosition.Manual;
+            Size = new Size(360, 54);
+            BackColor = Color.FromArgb(30, 30, 34);
+            Opacity = 0.95;
+            DoubleBuffered = true;
+
+            _anim = new Timer { Interval = 50 };
+            _anim.Tick += delegate
+            {
+                Array.Copy(_bars, 1, _bars, 0, _bars.Length - 1);
+                _bars[_bars.Length - 1] = _stage == Stage.Recording ? Level : 0;
+                Invalidate();
+            };
+        }
+
+        protected override bool ShowWithoutActivation
+        {
+            get { return true; }
+        }
+
+        protected override CreateParams CreateParams
+        {
+            get
+            {
+                var cp = base.CreateParams;
+                cp.ExStyle |= WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
+                return cp;
+            }
+        }
+
+        public void SetStage(Stage stage, string text)
+        {
+            _stage = stage;
+            _text = text ?? "";
+
+            if (stage == Stage.Idle)
+            {
+                _anim.Stop();
+                Hide();
+                return;
+            }
+
+            if (stage == Stage.Recording)
+            {
+                Array.Clear(_bars, 0, _bars.Length);
+                _anim.Start();
+            }
+            else
+            {
+                _anim.Stop();
+            }
+
+            PositionBottomCenter();
+            if (!Visible) Show();
+            Invalidate();
+        }
+
+        private void PositionBottomCenter()
+        {
+            var wa = Screen.PrimaryScreen.WorkingArea;
+            Location = new Point(wa.Left + (wa.Width - Width) / 2, wa.Bottom - Height - 28);
+        }
+
+        protected override void OnResize(EventArgs e)
+        {
+            base.OnResize(e);
+            using (var path = RoundedRect(new Rectangle(0, 0, Width, Height), 16))
+                Region = new Region(path);
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            var g = e.Graphics;
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+
+            Color accent;
+            switch (_stage)
+            {
+                case Stage.Recording: accent = Color.FromArgb(255, 82, 82); break;
+                case Stage.Transcribing: accent = Color.FromArgb(255, 170, 60); break;
+                case Stage.Correcting: accent = Color.FromArgb(180, 130, 255); break;
+                case Stage.Done: accent = Color.FromArgb(90, 210, 120); break;
+                case Stage.Error: accent = Color.FromArgb(255, 100, 100); break;
+                default: accent = Color.Gray; break;
+            }
+
+            // status dot
+            using (var b = new SolidBrush(accent))
+                g.FillEllipse(b, 16, Height / 2 - 5, 10, 10);
+
+            // waveform (recording only) on the right side
+            int barsRight = 18;
+            int barsWidth = _stage == Stage.Recording ? 96 : 0;
+            if (_stage == Stage.Recording)
+            {
+                int x0 = Width - barsRight - barsWidth;
+                int mid = Height / 2;
+                using (var b = new SolidBrush(Color.FromArgb(200, accent)))
+                {
+                    float step = barsWidth / (float)_bars.Length;
+                    for (int i = 0; i < _bars.Length; i++)
+                    {
+                        float h = Math.Max(2f, _bars[i] * (Height - 22));
+                        g.FillRectangle(b, x0 + i * step, mid - h / 2, Math.Max(1.5f, step - 1.5f), h);
+                    }
+                }
+            }
+
+            // status text
+            var textRect = new RectangleF(34, 0, Width - 34 - barsRight - barsWidth - 6, Height);
+            using (var sf = new StringFormat { LineAlignment = StringAlignment.Center, Trimming = StringTrimming.EllipsisCharacter, FormatFlags = StringFormatFlags.NoWrap })
+            using (var tb = new SolidBrush(Color.FromArgb(240, 240, 245)))
+                g.DrawString(_text, _font, tb, textRect, sf);
+        }
+
+        private static GraphicsPath RoundedRect(Rectangle r, int radius)
+        {
+            int d = radius * 2;
+            var path = new GraphicsPath();
+            path.AddArc(r.X, r.Y, d, d, 180, 90);
+            path.AddArc(r.Right - d, r.Y, d, d, 270, 90);
+            path.AddArc(r.Right - d, r.Bottom - d, d, d, 0, 90);
+            path.AddArc(r.X, r.Bottom - d, d, d, 90, 90);
+            path.CloseFigure();
+            return path;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _anim.Dispose();
+                _font.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/windows/src/Paster.cs
+++ b/windows/src/Paster.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace WhisperWin
+{
+    /// Copies text to the clipboard and simulates Ctrl+V into the focused app.
+    /// The text stays in the clipboard afterwards, so if auto-paste fails the user can Ctrl+V manually
+    /// (same behavior as the macOS version).
+    public static class Paster
+    {
+        /// Must be called from the UI (STA) thread.
+        public static async void Paste(string text)
+        {
+            try
+            {
+                Clipboard.SetDataObject(text, true, 5, 100);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Clipboard: " + ex.Message);
+                return;
+            }
+
+            await Task.Delay(60); // let the clipboard settle before the keystroke (macOS uses 50 ms)
+
+            try
+            {
+                SendCtrlV();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("SendInput: " + ex.Message);
+            }
+        }
+
+        private static void SendCtrlV()
+        {
+            const ushort VK_CONTROL = 0x11;
+            const ushort VK_V = 0x56;
+            const uint KEYEVENTF_KEYUP = 0x0002;
+
+            var inputs = new INPUT[4];
+            inputs[0] = KeyInput(VK_CONTROL, 0);
+            inputs[1] = KeyInput(VK_V, 0);
+            inputs[2] = KeyInput(VK_V, KEYEVENTF_KEYUP);
+            inputs[3] = KeyInput(VK_CONTROL, KEYEVENTF_KEYUP);
+
+            uint sent = SendInput((uint)inputs.Length, inputs, Marshal.SizeOf(typeof(INPUT)));
+            if (sent != inputs.Length)
+                Log.Error("SendInput sent " + sent + "/4: " + Marshal.GetLastWin32Error());
+        }
+
+        private static INPUT KeyInput(ushort vk, uint flags)
+        {
+            return new INPUT
+            {
+                type = 1, // INPUT_KEYBOARD
+                U = new InputUnion
+                {
+                    ki = new KEYBDINPUT { wVk = vk, wScan = 0, dwFlags = flags, time = 0, dwExtraInfo = IntPtr.Zero }
+                }
+            };
+        }
+
+        // ---------- P/Invoke ----------
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct INPUT
+        {
+            public uint type;
+            public InputUnion U;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct InputUnion
+        {
+            [FieldOffset(0)] public MOUSEINPUT mi;
+            [FieldOffset(0)] public KEYBDINPUT ki;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct MOUSEINPUT
+        {
+            public int dx, dy;
+            public uint mouseData, dwFlags, time;
+            public IntPtr dwExtraInfo;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct KEYBDINPUT
+        {
+            public ushort wVk, wScan;
+            public uint dwFlags, time;
+            public IntPtr dwExtraInfo;
+        }
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+    }
+}

--- a/windows/src/Program.cs
+++ b/windows/src/Program.cs
@@ -1,0 +1,109 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace WhisperWin
+{
+    public static class Program
+    {
+        [STAThread]
+        public static void Main(string[] args)
+        {
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
+            if (args.Length > 0 && args[0] == "--selftest")
+            {
+                SelfTest.Run(args.Length > 1 ? args[1] : "selftest.txt");
+                return;
+            }
+
+            bool createdNew;
+            using (new Mutex(true, "WhisperAppWin-SingleInstance", out createdNew))
+            {
+                if (!createdNew)
+                {
+                    MessageBox.Show("WhisperApp เปิดอยู่แล้ว — ดูไอคอนไมโครโฟนที่ tray (มุมขวาล่าง)",
+                        "WhisperApp", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    return;
+                }
+
+                SetProcessDPIAware();
+                Application.EnableVisualStyles();
+                Application.SetCompatibleTextRenderingDefault(false);
+                Application.ThreadException += delegate(object s, ThreadExceptionEventArgs e)
+                {
+                    Log.Error("UI exception: " + e.Exception);
+                };
+                AppDomain.CurrentDomain.UnhandledException += delegate(object s, UnhandledExceptionEventArgs e)
+                {
+                    Log.Error("Fatal: " + e.ExceptionObject);
+                };
+
+                Application.Run(new TrayContext());
+            }
+        }
+
+        [DllImport("user32.dll")]
+        private static extern bool SetProcessDPIAware();
+    }
+
+    /// Headless smoke test (--selftest [outfile]) — verifies config round-trip and microphone capture
+    /// without touching the network or the real config file.
+    public static class SelfTest
+    {
+        public static void Run(string outPath)
+        {
+            var r = new StringBuilder();
+            r.AppendLine("WhisperApp for Windows — self test");
+            r.AppendLine("time: " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
+            r.AppendLine("64-bit process: " + Environment.Is64BitProcess);
+
+            try
+            {
+                var cfg = new AppConfig();
+                var json = Json.Serializer().Serialize(cfg);
+                var back = Json.Serializer().Deserialize<AppConfig>(json);
+                r.AppendLine("config json round-trip: " + (back != null && back.SttProvider == cfg.SttProvider ? "OK" : "FAIL"));
+            }
+            catch (Exception ex) { r.AppendLine("config json round-trip: FAIL — " + ex.Message); }
+
+            r.AppendLine("stt providers: " + SttRegistry.All.Count + ", llm providers: " + LlmRegistry.All.Count);
+
+            try
+            {
+                var rec = new AudioRecorder();
+                if (rec.Start())
+                {
+                    Thread.Sleep(500);
+                    var lvl = rec.Level;
+                    var wav = rec.Stop();
+                    if (wav != null)
+                    {
+                        var size = new FileInfo(wav).Length;
+                        r.AppendLine("microphone: OK — recorded " + size + " bytes in 0.5s (level " + lvl.ToString("0.00") + ")");
+                        r.AppendLine("wav header: " + (size > 44 ? "OK" : "FAIL (empty)"));
+                        File.Delete(wav);
+                    }
+                    else r.AppendLine("microphone: opened but produced no data");
+                }
+                else r.AppendLine("microphone: NOT FOUND (waveInOpen failed) — ต่อไมค์หรือเช็คสิทธิ์ไมโครโฟน");
+            }
+            catch (Exception ex) { r.AppendLine("microphone: FAIL — " + ex.Message); }
+
+            try
+            {
+                var cfg = new AppConfig();
+                r.AppendLine("local whisper exe: " + (LocalWhisper.FindExe(cfg) ?? "(not installed — cloud only)"));
+            }
+            catch (Exception ex) { r.AppendLine("local whisper: " + ex.Message); }
+
+            try { File.WriteAllText(outPath, r.ToString(), Encoding.UTF8); }
+            catch { }
+            Log.Info("selftest:\n" + r);
+        }
+    }
+}

--- a/windows/src/Providers.cs
+++ b/windows/src/Providers.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WhisperWin
+{
+    public enum SttStyle { OpenAI, ElevenLabs }
+    public enum LlmStyle { OpenAI, Anthropic }
+
+    /// STT provider presets — mirrors STTProvider.swift
+    public class SttProvider
+    {
+        public string Id;
+        public string Name;
+        public string DefaultEndpoint;
+        public string DefaultModel;
+        public string EnvKey;
+        public SttStyle Style;
+        public bool IsCustom;
+
+        public override string ToString() { return Name; } // shown in settings combo box
+    }
+
+    /// LLM provider presets — mirrors LLMProvider.swift
+    public class LlmProvider
+    {
+        public string Id;
+        public string Name;
+        public string DefaultEndpoint;
+        public string DefaultModel;
+        public string EnvKey;
+        public LlmStyle Style;
+        public bool IsCustom;
+
+        public override string ToString() { return Name; } // shown in settings combo box
+    }
+
+    public static class SttRegistry
+    {
+        public static readonly List<SttProvider> All = new List<SttProvider>
+        {
+            new SttProvider { Id = "elevenlabs", Name = "ElevenLabs Scribe",
+                DefaultEndpoint = "https://api.elevenlabs.io/v1/speech-to-text",
+                DefaultModel = "scribe_v1", EnvKey = "ELEVENLABS_API_KEY", Style = SttStyle.ElevenLabs },
+            new SttProvider { Id = "openai", Name = "OpenAI",
+                DefaultEndpoint = "https://api.openai.com/v1/audio/transcriptions",
+                DefaultModel = "gpt-4o-transcribe", EnvKey = "OPENAI_API_KEY", Style = SttStyle.OpenAI },
+            new SttProvider { Id = "groq", Name = "Groq (Whisper)",
+                DefaultEndpoint = "https://api.groq.com/openai/v1/audio/transcriptions",
+                DefaultModel = "whisper-large-v3-turbo", EnvKey = "GROQ_API_KEY", Style = SttStyle.OpenAI },
+            new SttProvider { Id = "stt_custom", Name = "Custom (OpenAI-compatible)",
+                DefaultEndpoint = "", DefaultModel = "", EnvKey = "STT_API_KEY",
+                Style = SttStyle.OpenAI, IsCustom = true },
+        };
+
+        public static SttProvider Get(string id)
+        {
+            return All.FirstOrDefault(p => p.Id == id) ?? All[0];
+        }
+    }
+
+    public static class LlmRegistry
+    {
+        public static readonly List<LlmProvider> All = new List<LlmProvider>
+        {
+            new LlmProvider { Id = "deepseek", Name = "DeepSeek",
+                DefaultEndpoint = "https://api.deepseek.com/chat/completions",
+                DefaultModel = "deepseek-chat", EnvKey = "DEEPSEEK_API_KEY", Style = LlmStyle.OpenAI },
+            new LlmProvider { Id = "openai", Name = "OpenAI",
+                DefaultEndpoint = "https://api.openai.com/v1/chat/completions",
+                DefaultModel = "gpt-4o-mini", EnvKey = "OPENAI_API_KEY", Style = LlmStyle.OpenAI },
+            new LlmProvider { Id = "groq", Name = "Groq",
+                DefaultEndpoint = "https://api.groq.com/openai/v1/chat/completions",
+                DefaultModel = "llama-3.3-70b-versatile", EnvKey = "GROQ_API_KEY", Style = LlmStyle.OpenAI },
+            new LlmProvider { Id = "openrouter", Name = "OpenRouter",
+                DefaultEndpoint = "https://openrouter.ai/api/v1/chat/completions",
+                DefaultModel = "google/gemini-2.0-flash-001", EnvKey = "OPENROUTER_API_KEY", Style = LlmStyle.OpenAI },
+            new LlmProvider { Id = "gemini", Name = "Google Gemini",
+                DefaultEndpoint = "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+                DefaultModel = "gemini-2.0-flash", EnvKey = "GEMINI_API_KEY", Style = LlmStyle.OpenAI },
+            new LlmProvider { Id = "anthropic", Name = "Anthropic (Claude)",
+                DefaultEndpoint = "https://api.anthropic.com/v1/messages",
+                DefaultModel = "claude-haiku-4-5", EnvKey = "ANTHROPIC_API_KEY", Style = LlmStyle.Anthropic },
+            new LlmProvider { Id = "glm", Name = "GLM (Z.AI)",
+                DefaultEndpoint = "https://api.z.ai/api/anthropic/v1/messages",
+                DefaultModel = "glm-5.2", EnvKey = "ZAI_API_KEY", Style = LlmStyle.Anthropic },
+            new LlmProvider { Id = "custom", Name = "Custom (OpenAI-compatible)",
+                DefaultEndpoint = "", DefaultModel = "", EnvKey = "LLM_API_KEY",
+                Style = LlmStyle.OpenAI, IsCustom = true },
+        };
+
+        public static LlmProvider Get(string id)
+        {
+            return All.FirstOrDefault(p => p.Id == id) ?? All[0];
+        }
+    }
+}

--- a/windows/src/SettingsForm.cs
+++ b/windows/src/SettingsForm.cs
@@ -1,0 +1,347 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace WhisperWin
+{
+    /// Settings dialog — provider keys/models/endpoints, language, hotkey, autostart, local whisper.
+    public class SettingsForm : Form
+    {
+        private readonly AppConfig _cfg;
+
+        // working copies so Cancel discards edits
+        private readonly Dictionary<string, string> _sttKeys, _sttModels, _sttEndpoints;
+        private readonly Dictionary<string, string> _llmKeys, _llmModels, _llmEndpoints;
+        private string _sttPrev, _llmPrev;
+
+        private ComboBox _cboStt, _cboLlm, _cboLang, _cboKey;
+        private TextBox _txtSttKey, _txtSttModel, _txtSttEndpoint;
+        private TextBox _txtLlmKey, _txtLlmModel, _txtLlmEndpoint;
+        private CheckBox _chkCorrection, _chkCtrl, _chkAlt, _chkShift, _chkAutostart, _chkLocal;
+        private RadioButton _radHold, _radToggle;
+        private TextBox _txtWhisperExe, _txtModelDir;
+
+        public event Action Saved;
+
+        private class KeyItem
+        {
+            public string Name; public int Vk;
+            public override string ToString() { return Name; }
+        }
+
+        private static readonly KeyItem[] HotkeyChoices = BuildKeyChoices();
+
+        private static KeyItem[] BuildKeyChoices()
+        {
+            var list = new List<KeyItem>();
+            for (int i = 0; i < 12; i++)
+                list.Add(new KeyItem { Name = "F" + (i + 1), Vk = 0x70 + i });
+            list.Add(new KeyItem { Name = "CapsLock", Vk = 0x14 });
+            list.Add(new KeyItem { Name = "ScrollLock", Vk = 0x91 });
+            list.Add(new KeyItem { Name = "Pause", Vk = 0x13 });
+            list.Add(new KeyItem { Name = "Insert", Vk = 0x2D });
+            list.Add(new KeyItem { Name = "Home", Vk = 0x24 });
+            list.Add(new KeyItem { Name = "End", Vk = 0x23 });
+            list.Add(new KeyItem { Name = "PageUp", Vk = 0x21 });
+            list.Add(new KeyItem { Name = "PageDown", Vk = 0x22 });
+            list.Add(new KeyItem { Name = "Space", Vk = 0x20 });
+            list.Add(new KeyItem { Name = "Right Ctrl", Vk = 0xA3 });
+            list.Add(new KeyItem { Name = "Right Alt", Vk = 0xA5 });
+            list.Add(new KeyItem { Name = "Right Shift", Vk = 0xA1 });
+            return list.ToArray();
+        }
+
+        private static readonly HashSet<int> ModifierVks = new HashSet<int> { 0x14, 0xA1, 0xA3, 0xA5 };
+
+        public SettingsForm(AppConfig cfg)
+        {
+            _cfg = cfg;
+            _sttKeys = new Dictionary<string, string>(cfg.SttKeys);
+            _sttModels = new Dictionary<string, string>(cfg.SttModels);
+            _sttEndpoints = new Dictionary<string, string>(cfg.SttEndpoints);
+            _llmKeys = new Dictionary<string, string>(cfg.LlmKeys);
+            _llmModels = new Dictionary<string, string>(cfg.LlmModels);
+            _llmEndpoints = new Dictionary<string, string>(cfg.LlmEndpoints);
+
+            Text = "WhisperApp — ตั้งค่า";
+            Font = new Font("Segoe UI", 9.5f);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            StartPosition = FormStartPosition.CenterScreen;
+            ClientSize = new Size(560, 716);
+
+            BuildUi();
+            LoadFromConfig();
+        }
+
+        // ---------- UI construction ----------
+
+        private void BuildUi()
+        {
+            int y = 12;
+
+            // --- STT group ---
+            var gStt = AddGroup("ถอดเสียงเป็นข้อความ (Speech-to-Text)", y, 152);
+            _cboStt = AddCombo(gStt, "ผู้ให้บริการ", 26, SttRegistry.All.Cast<object>().ToArray());
+            _txtSttKey = AddText(gStt, "API key", 56, 400, true);
+            _txtSttModel = AddText(gStt, "โมเดล", 86, 250, false);
+            _txtSttEndpoint = AddText(gStt, "Endpoint", 116, 400, false);
+            _cboStt.SelectedIndexChanged += delegate { OnSttProviderChanged(); };
+            y += 152 + 10;
+
+            // --- LLM group ---
+            var gLlm = AddGroup("เกลาข้อความด้วย AI (แก้คำผิด เว้นวรรค ใส่วรรคตอน)", y, 182);
+            _chkCorrection = AddCheck(gLlm, "เปิดใช้งาน — ส่งข้อความผ่าน LLM ก่อนพิมพ์", 26);
+            _cboLlm = AddCombo(gLlm, "ผู้ให้บริการ", 56, LlmRegistry.All.Cast<object>().ToArray());
+            _txtLlmKey = AddText(gLlm, "API key", 86, 400, true);
+            _txtLlmModel = AddText(gLlm, "โมเดล", 116, 250, false);
+            _txtLlmEndpoint = AddText(gLlm, "Endpoint", 146, 400, false);
+            _cboLlm.SelectedIndexChanged += delegate { OnLlmProviderChanged(); };
+            y += 182 + 10;
+
+            // --- General group ---
+            var gGen = AddGroup("ทั่วไป", y, 148);
+            _cboLang = AddCombo(gGen, "ภาษาที่พูด", 26, new object[] { "ไทย", "English", "ตรวจอัตโนมัติ" });
+
+            AddLabel(gGen, "ปุ่มลัด", 60);
+            _cboKey = new ComboBox { Left = 130, Top = 56, Width = 110, DropDownStyle = ComboBoxStyle.DropDownList };
+            _cboKey.Items.AddRange(HotkeyChoices.Cast<object>().ToArray());
+            _cboKey.SelectedIndexChanged += delegate { UpdateModifierBoxes(); };
+            gGen.Controls.Add(_cboKey);
+            _chkCtrl = new CheckBox { Text = "Ctrl", Left = 250, Top = 57, Width = 55 };
+            _chkAlt = new CheckBox { Text = "Alt", Left = 305, Top = 57, Width = 50 };
+            _chkShift = new CheckBox { Text = "Shift", Left = 355, Top = 57, Width = 60 };
+            gGen.Controls.AddRange(new Control[] { _chkCtrl, _chkAlt, _chkShift });
+
+            _radHold = new RadioButton { Text = "กดค้างเพื่อพูด ปล่อยแล้วพิมพ์ (push-to-talk)", Left = 130, Top = 86, Width = 400, Checked = true };
+            _radToggle = new RadioButton { Text = "กดครั้งแรกเริ่มอัด กดอีกครั้งหยุด", Left = 130, Top = 112, Width = 400 };
+            gGen.Controls.AddRange(new Control[] { _radHold, _radToggle });
+            y += 148 + 10;
+
+            // --- Local whisper group ---
+            var gLocal = AddGroup("Whisper ในเครื่อง (ออฟไลน์ — ไม่บังคับ)", y, 118);
+            _chkLocal = AddCheck(gLocal, "ใช้ whisper.cpp ในเครื่องแทน cloud", 26);
+            _txtWhisperExe = AddText(gLocal, "whisper-cli.exe", 56, 400, false);
+            _txtModelDir = AddText(gLocal, "โฟลเดอร์โมเดล", 86, 400, false);
+            y += 118 + 10;
+
+            _chkAutostart = new CheckBox { Text = "เริ่มโปรแกรมอัตโนมัติเมื่อเปิดเครื่อง", Left = 22, Top = y, Width = 300 };
+            Controls.Add(_chkAutostart);
+            y += 34;
+
+            var btnSave = new Button { Text = "บันทึก", Left = 356, Top = y, Width = 92, Height = 30 };
+            var btnCancel = new Button { Text = "ยกเลิก", Left = 456, Top = y, Width = 92, Height = 30 };
+            btnSave.Click += delegate { SaveAndClose(); };
+            btnCancel.Click += delegate { Close(); };
+            Controls.AddRange(new Control[] { btnSave, btnCancel });
+            AcceptButton = btnSave;
+            CancelButton = btnCancel;
+        }
+
+        private GroupBox AddGroup(string title, int y, int height)
+        {
+            var g = new GroupBox { Text = title, Left = 12, Top = y, Width = 536, Height = height };
+            Controls.Add(g);
+            return g;
+        }
+
+        private void AddLabel(GroupBox g, string text, int y)
+        {
+            g.Controls.Add(new Label { Text = text, Left = 14, Top = y, Width = 112, TextAlign = ContentAlignment.MiddleLeft });
+        }
+
+        private ComboBox AddCombo(GroupBox g, string label, int y, object[] items)
+        {
+            AddLabel(g, label, y + 4);
+            var cbo = new ComboBox { Left = 130, Top = y, Width = 240, DropDownStyle = ComboBoxStyle.DropDownList };
+            cbo.Items.AddRange(items);
+            g.Controls.Add(cbo);
+            return cbo;
+        }
+
+        private CheckBox AddCheck(GroupBox g, string text, int y)
+        {
+            var chk = new CheckBox { Text = text, Left = 130, Top = y, Width = 392 };
+            g.Controls.Add(chk);
+            return chk;
+        }
+
+        private TextBox AddText(GroupBox g, string label, int y, int width, bool password)
+        {
+            AddLabel(g, label, y + 3);
+            var txt = new TextBox { Left = 130, Top = y, Width = width };
+            if (password) txt.UseSystemPasswordChar = true;
+            g.Controls.Add(txt);
+            return txt;
+        }
+
+        // ---------- load / stash / save ----------
+
+        private void LoadFromConfig()
+        {
+            _cboStt.SelectedIndex = Math.Max(0, SttRegistry.All.FindIndex(p => p.Id == _cfg.SttProvider));
+            _sttPrev = CurrentStt().Id;
+            LoadSttFields(CurrentStt());
+
+            _chkCorrection.Checked = _cfg.UseCorrection;
+            _cboLlm.SelectedIndex = Math.Max(0, LlmRegistry.All.FindIndex(p => p.Id == _cfg.LlmProvider));
+            _llmPrev = CurrentLlm().Id;
+            LoadLlmFields(CurrentLlm());
+
+            _cboLang.SelectedIndex = _cfg.Language == "en" ? 1 : (_cfg.Language == "auto" ? 2 : 0);
+
+            int keyIdx = Array.FindIndex(HotkeyChoices, k => k.Vk == _cfg.HotkeyVk);
+            _cboKey.SelectedIndex = keyIdx >= 0 ? keyIdx : 8; // F9
+            _chkCtrl.Checked = _cfg.HotkeyCtrl;
+            _chkAlt.Checked = _cfg.HotkeyAlt;
+            _chkShift.Checked = _cfg.HotkeyShift;
+            _radHold.Checked = _cfg.HotkeyHoldMode;
+            _radToggle.Checked = !_cfg.HotkeyHoldMode;
+            UpdateModifierBoxes();
+
+            _chkLocal.Checked = !_cfg.UseCloudStt;
+            _txtWhisperExe.Text = _cfg.LocalWhisperExe ?? "";
+            _txtModelDir.Text = _cfg.LocalWhisperModelDir ?? "";
+            SetCue(_txtWhisperExe, "ค้นหาอัตโนมัติ (PATH หรือ %USERPROFILE%\\.whisper-models)");
+            SetCue(_txtModelDir, LocalWhisper.DefaultModelDir);
+
+            _chkAutostart.Checked = Autostart.IsEnabled();
+        }
+
+        private SttProvider CurrentStt() { return (SttProvider)_cboStt.SelectedItem; }
+        private LlmProvider CurrentLlm() { return (LlmProvider)_cboLlm.SelectedItem; }
+
+        private void OnSttProviderChanged()
+        {
+            StashStt(_sttPrev);
+            var p = CurrentStt();
+            _sttPrev = p.Id;
+            LoadSttFields(p);
+        }
+
+        private void OnLlmProviderChanged()
+        {
+            StashLlm(_llmPrev);
+            var p = CurrentLlm();
+            _llmPrev = p.Id;
+            LoadLlmFields(p);
+        }
+
+        private static string DictGet(Dictionary<string, string> d, string k)
+        {
+            string v;
+            return d.TryGetValue(k, out v) ? v : "";
+        }
+
+        private static void DictSet(Dictionary<string, string> d, string k, string v)
+        {
+            if (string.IsNullOrWhiteSpace(v)) d.Remove(k);
+            else d[k] = v.Trim();
+        }
+
+        private void LoadSttFields(SttProvider p)
+        {
+            _txtSttKey.Text = DictGet(_sttKeys, p.Id);
+            _txtSttModel.Text = DictGet(_sttModels, p.Id);
+            _txtSttEndpoint.Text = DictGet(_sttEndpoints, p.Id);
+            SetCue(_txtSttKey, EnvHint(p.EnvKey));
+            SetCue(_txtSttModel, p.DefaultModel);
+            SetCue(_txtSttEndpoint, p.DefaultEndpoint);
+        }
+
+        private void LoadLlmFields(LlmProvider p)
+        {
+            _txtLlmKey.Text = DictGet(_llmKeys, p.Id);
+            _txtLlmModel.Text = DictGet(_llmModels, p.Id);
+            _txtLlmEndpoint.Text = DictGet(_llmEndpoints, p.Id);
+            SetCue(_txtLlmKey, EnvHint(p.EnvKey));
+            SetCue(_txtLlmModel, p.DefaultModel);
+            SetCue(_txtLlmEndpoint, p.DefaultEndpoint);
+        }
+
+        private static string EnvHint(string envKey)
+        {
+            var v = Environment.GetEnvironmentVariable(envKey);
+            return string.IsNullOrWhiteSpace(v)
+                ? "วางคีย์ที่นี่ (หรือตั้ง env " + envKey + ")"
+                : "ใช้จาก env " + envKey + " (ใส่เพื่อ override)";
+        }
+
+        private void StashStt(string id)
+        {
+            if (id == null) return;
+            DictSet(_sttKeys, id, _txtSttKey.Text);
+            DictSet(_sttModels, id, _txtSttModel.Text);
+            DictSet(_sttEndpoints, id, _txtSttEndpoint.Text);
+        }
+
+        private void StashLlm(string id)
+        {
+            if (id == null) return;
+            DictSet(_llmKeys, id, _txtLlmKey.Text);
+            DictSet(_llmModels, id, _txtLlmModel.Text);
+            DictSet(_llmEndpoints, id, _txtLlmEndpoint.Text);
+        }
+
+        private void UpdateModifierBoxes()
+        {
+            var item = (KeyItem)_cboKey.SelectedItem;
+            bool isModifier = item != null && ModifierVks.Contains(item.Vk);
+            _chkCtrl.Enabled = _chkAlt.Enabled = _chkShift.Enabled = !isModifier;
+            if (isModifier) _chkCtrl.Checked = _chkAlt.Checked = _chkShift.Checked = false;
+        }
+
+        private void SaveAndClose()
+        {
+            StashStt(CurrentStt().Id);
+            StashLlm(CurrentLlm().Id);
+
+            _cfg.SttProvider = CurrentStt().Id;
+            _cfg.SttKeys.Clear(); foreach (var kv in _sttKeys) _cfg.SttKeys[kv.Key] = kv.Value;
+            _cfg.SttModels.Clear(); foreach (var kv in _sttModels) _cfg.SttModels[kv.Key] = kv.Value;
+            _cfg.SttEndpoints.Clear(); foreach (var kv in _sttEndpoints) _cfg.SttEndpoints[kv.Key] = kv.Value;
+
+            _cfg.UseCorrection = _chkCorrection.Checked;
+            _cfg.LlmProvider = CurrentLlm().Id;
+            _cfg.LlmKeys.Clear(); foreach (var kv in _llmKeys) _cfg.LlmKeys[kv.Key] = kv.Value;
+            _cfg.LlmModels.Clear(); foreach (var kv in _llmModels) _cfg.LlmModels[kv.Key] = kv.Value;
+            _cfg.LlmEndpoints.Clear(); foreach (var kv in _llmEndpoints) _cfg.LlmEndpoints[kv.Key] = kv.Value;
+
+            _cfg.Language = _cboLang.SelectedIndex == 1 ? "en" : (_cboLang.SelectedIndex == 2 ? "auto" : "th");
+
+            var key = (KeyItem)_cboKey.SelectedItem;
+            if (key != null) _cfg.HotkeyVk = key.Vk;
+            _cfg.HotkeyCtrl = _chkCtrl.Checked;
+            _cfg.HotkeyAlt = _chkAlt.Checked;
+            _cfg.HotkeyShift = _chkShift.Checked;
+            _cfg.HotkeyHoldMode = _radHold.Checked;
+
+            _cfg.UseCloudStt = !_chkLocal.Checked;
+            _cfg.LocalWhisperExe = _txtWhisperExe.Text.Trim();
+            _cfg.LocalWhisperModelDir = _txtModelDir.Text.Trim();
+
+            _cfg.Save();
+            Autostart.Set(_chkAutostart.Checked);
+
+            var cb = Saved;
+            if (cb != null) cb();
+            Close();
+        }
+
+        // ---------- cue banner (placeholder text) ----------
+
+        private const int EM_SETCUEBANNER = 0x1501;
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, string lParam);
+
+        private static void SetCue(TextBox txt, string text)
+        {
+            SendMessage(txt.Handle, EM_SETCUEBANNER, (IntPtr)1, text ?? "");
+        }
+    }
+}

--- a/windows/src/SttClient.cs
+++ b/windows/src/SttClient.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WhisperWin
+{
+    /// Cloud speech-to-text — multipart upload, mirrors CloudTranscriptionService.swift.
+    /// OpenAI style: Bearer auth, fields model/language (ISO 639-1)
+    /// ElevenLabs style: xi-api-key header, fields model_id/language_code (ISO 639-3)
+    public static class SttClient
+    {
+        public static readonly HttpClient Http = CreateClient();
+
+        private static HttpClient CreateClient()
+        {
+            var c = new HttpClient();
+            c.Timeout = Timeout.InfiniteTimeSpan; // per-request timeouts via CancellationToken
+            return c;
+        }
+
+        private static string LangCode(string language, SttStyle style)
+        {
+            if (language == "th") return style == SttStyle.ElevenLabs ? "tha" : "th";
+            if (language == "en") return style == SttStyle.ElevenLabs ? "eng" : "en";
+            return null; // auto → let the provider detect
+        }
+
+        /// Returns transcribed text, or throws with a readable message.
+        public static async Task<string> TranscribeAsync(AppConfig cfg, string wavPath, string language)
+        {
+            var p = SttRegistry.Get(cfg.SttProvider);
+            var key = cfg.SttKey(p);
+            if (string.IsNullOrEmpty(key))
+                throw new InvalidOperationException("ยังไม่ได้ตั้งค่า API key ของ " + p.Name);
+            var endpoint = cfg.SttEndpoint(p);
+            if (string.IsNullOrEmpty(endpoint))
+                throw new InvalidOperationException("ยังไม่ได้ตั้งค่า endpoint ของ " + p.Name);
+
+            byte[] audio = File.ReadAllBytes(wavPath);
+
+            using (var form = new MultipartFormDataContent("Boundary-" + Guid.NewGuid().ToString("N")))
+            using (var req = new HttpRequestMessage(HttpMethod.Post, endpoint))
+            {
+                string modelField = p.Style == SttStyle.ElevenLabs ? "model_id" : "model";
+                string langField = p.Style == SttStyle.ElevenLabs ? "language_code" : "language";
+
+                var model = cfg.SttModel(p);
+                if (!string.IsNullOrEmpty(model))
+                    form.Add(new StringContent(model), modelField);
+
+                var lang = LangCode(language, p.Style);
+                if (lang != null)
+                    form.Add(new StringContent(lang), langField);
+
+                var fileContent = new ByteArrayContent(audio);
+                fileContent.Headers.ContentType = MediaTypeHeaderValue.Parse("audio/wav");
+                form.Add(fileContent, "file", "audio.wav");
+
+                if (p.Style == SttStyle.ElevenLabs)
+                    req.Headers.TryAddWithoutValidation("xi-api-key", key);
+                else
+                    req.Headers.TryAddWithoutValidation("Authorization", "Bearer " + key);
+
+                req.Content = form;
+
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120)))
+                using (var resp = await Http.SendAsync(req, cts.Token).ConfigureAwait(false))
+                {
+                    var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Log.Error(p.Name + " HTTP " + (int)resp.StatusCode + ": " + Truncate(body, 500));
+                        throw new InvalidOperationException(p.Name + " ตอบกลับ HTTP " + (int)resp.StatusCode);
+                    }
+
+                    var json = Json.ParseObject(body);
+                    var text = Json.AsString(Json.Get(json, "text"));
+                    if (text == null)
+                    {
+                        Log.Error(p.Name + " unexpected response: " + Truncate(body, 500));
+                        throw new InvalidOperationException("อ่านผลลัพธ์จาก " + p.Name + " ไม่ได้");
+                    }
+                    return text.Trim();
+                }
+            }
+        }
+
+        public static string Truncate(string s, int n)
+        {
+            if (s == null) return "";
+            return s.Length <= n ? s : s.Substring(0, n) + "…";
+        }
+    }
+}

--- a/windows/src/TextCleaner.cs
+++ b/windows/src/TextCleaner.cs
@@ -1,0 +1,31 @@
+using System.Text.RegularExpressions;
+
+namespace WhisperWin
+{
+    /// Strips sound-event annotations that STT engines insert, e.g. (เสียงลม) (wind) [applause] *laughs*
+    /// Ported from DictationController.stripSoundAnnotations in the macOS version.
+    public static class TextCleaner
+    {
+        private static readonly string[] Patterns =
+        {
+            @"\([^\)]*\)",   // ( ... )
+            "（[^）]*）",      // （ ... ） fullwidth
+            @"\[[^\]]*\]",   // [ ... ]
+            "【[^】]*】",      // 【 ... 】
+            @"\*[^*]*\*",    // * ... *
+            "‹[^›]*›",
+            "«[^»]*»",
+        };
+
+        public static string StripSoundAnnotations(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return "";
+            var result = text;
+            foreach (var p in Patterns)
+                result = Regex.Replace(result, p, " ");
+            result = Regex.Replace(result, @"\s{2,}", " ");
+            result = Regex.Replace(result, @"\s+([,.!?])", "$1");
+            return result.Trim();
+        }
+    }
+}

--- a/windows/src/TrayContext.cs
+++ b/windows/src/TrayContext.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Threading;
+using System.Windows.Forms;
+using Microsoft.Win32;
+
+namespace WhisperWin
+{
+    /// System-tray application shell: icon, menu, hotkey wiring, settings window.
+    public class TrayContext : ApplicationContext
+    {
+        private readonly AppConfig _cfg;
+        private readonly Overlay _overlay;
+        private readonly DictationController _controller;
+        private readonly HotkeyManager _hotkey;
+        private readonly NotifyIcon _tray;
+        private readonly SynchronizationContext _ui;
+
+        private readonly Icon _iconIdle = TrayIcons.Make(Color.White);
+        private readonly Icon _iconRec = TrayIcons.Make(Color.FromArgb(255, 82, 82));
+        private readonly Icon _iconBusy = TrayIcons.Make(Color.FromArgb(255, 170, 60));
+
+        private ToolStripMenuItem _miToggle;
+        private ToolStripMenuItem _miCorrection;
+        private ToolStripMenuItem _miAutostart;
+        private ToolStripMenuItem _miLangTh, _miLangEn, _miLangAuto;
+        private SettingsForm _settings;
+
+        public TrayContext()
+        {
+            _cfg = AppConfig.Load();
+            _overlay = new Overlay(); // creating the first Form installs the WinForms SynchronizationContext
+            _ui = SynchronizationContext.Current;
+
+            _controller = new DictationController(_cfg, _overlay);
+            _controller.StageChanged += OnStageChanged;
+
+            _hotkey = new HotkeyManager();
+            ApplyHotkeySettings();
+            // hook callbacks run inside message dispatch — post so the hook returns instantly
+            _hotkey.OnKeyDown = delegate
+            {
+                _ui.Post(delegate { if (_cfg.HotkeyHoldMode) _controller.Start(); else _controller.Toggle(); }, null);
+            };
+            _hotkey.OnKeyUp = delegate
+            {
+                _ui.Post(delegate { _controller.StopAndProcess(); }, null);
+            };
+            _hotkey.Install();
+
+            _tray = new NotifyIcon
+            {
+                Icon = _iconIdle,
+                Visible = true,
+                ContextMenuStrip = BuildMenu(),
+            };
+            _tray.MouseClick += delegate(object s, MouseEventArgs e)
+            {
+                if (e.Button == MouseButtons.Left) _controller.Toggle();
+            };
+            UpdateTexts();
+
+            Log.Info("WhisperApp started (hotkey: " + _hotkey.DisplayString + ")");
+
+            if (!_cfg.SttConfigured())
+            {
+                _tray.ShowBalloonTip(6000, "WhisperApp",
+                    "ยังไม่ได้ตั้งค่า API key — เปิดหน้าตั้งค่าเพื่อเริ่มใช้งาน", ToolTipIcon.Info);
+                OpenSettings();
+            }
+        }
+
+        private void ApplyHotkeySettings()
+        {
+            _hotkey.Vk = _cfg.HotkeyVk;
+            _hotkey.Ctrl = _cfg.HotkeyCtrl;
+            _hotkey.Alt = _cfg.HotkeyAlt;
+            _hotkey.Shift = _cfg.HotkeyShift;
+            _hotkey.HoldMode = _cfg.HotkeyHoldMode;
+        }
+
+        private ContextMenuStrip BuildMenu()
+        {
+            var menu = new ContextMenuStrip();
+
+            var header = new ToolStripMenuItem("WhisperApp — พูดแล้วพิมพ์ให้อัตโนมัติ") { Enabled = false };
+            menu.Items.Add(header);
+            menu.Items.Add(new ToolStripSeparator());
+
+            _miToggle = new ToolStripMenuItem("เริ่มพูด");
+            _miToggle.Click += delegate { _controller.Toggle(); };
+            menu.Items.Add(_miToggle);
+            menu.Items.Add(new ToolStripSeparator());
+
+            var lang = new ToolStripMenuItem("ภาษา");
+            _miLangTh = AddLang(lang, "ไทย", "th");
+            _miLangEn = AddLang(lang, "English", "en");
+            _miLangAuto = AddLang(lang, "ตรวจอัตโนมัติ", "auto");
+            menu.Items.Add(lang);
+
+            _miCorrection = new ToolStripMenuItem("เกลาข้อความด้วย AI") { CheckOnClick = true };
+            _miCorrection.CheckedChanged += delegate
+            {
+                _cfg.UseCorrection = _miCorrection.Checked;
+                _cfg.Save();
+            };
+            menu.Items.Add(_miCorrection);
+            menu.Items.Add(new ToolStripSeparator());
+
+            var settings = new ToolStripMenuItem("ตั้งค่า…");
+            settings.Click += delegate { OpenSettings(); };
+            menu.Items.Add(settings);
+
+            _miAutostart = new ToolStripMenuItem("เริ่มพร้อม Windows") { CheckOnClick = true };
+            _miAutostart.CheckedChanged += delegate { Autostart.Set(_miAutostart.Checked); };
+            menu.Items.Add(_miAutostart);
+
+            var openDir = new ToolStripMenuItem("เปิดโฟลเดอร์ข้อมูล (config/log)");
+            openDir.Click += delegate
+            {
+                try
+                {
+                    System.IO.Directory.CreateDirectory(AppConfig.Dir);
+                    Process.Start("explorer.exe", AppConfig.Dir);
+                }
+                catch { }
+            };
+            menu.Items.Add(openDir);
+            menu.Items.Add(new ToolStripSeparator());
+
+            var about = new ToolStripMenuItem("เกี่ยวกับ WhisperApp");
+            about.Click += delegate
+            {
+                MessageBox.Show(
+                    "WhisperApp for Windows\n\n" +
+                    "พูดผ่านไมค์ → ถอดเสียงเป็นข้อความ → AI เกลาให้ → พิมพ์ลงแอปที่ใช้อยู่อัตโนมัติ\n" +
+                    "(port มาจากเวอร์ชัน macOS: github.com/Gamezxz/WhisperApp)\n\n" +
+                    "ปุ่มลัดปัจจุบัน: " + _hotkey.DisplayString +
+                    (_cfg.HotkeyHoldMode ? " (กดค้างเพื่อพูด)" : " (กดเริ่ม/หยุด)"),
+                    "WhisperApp", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            };
+            menu.Items.Add(about);
+
+            var exit = new ToolStripMenuItem("ออก");
+            exit.Click += delegate { ExitApp(); };
+            menu.Items.Add(exit);
+
+            return menu;
+        }
+
+        private ToolStripMenuItem AddLang(ToolStripMenuItem parent, string label, string code)
+        {
+            var item = new ToolStripMenuItem(label);
+            item.Click += delegate
+            {
+                _cfg.Language = code;
+                _cfg.Save();
+                UpdateTexts();
+            };
+            parent.DropDownItems.Add(item);
+            return item;
+        }
+
+        private void OpenSettings()
+        {
+            if (_settings != null && !_settings.IsDisposed)
+            {
+                _settings.Activate();
+                return;
+            }
+            _settings = new SettingsForm(_cfg);
+            _settings.Saved += delegate
+            {
+                ApplyHotkeySettings();
+                UpdateTexts();
+            };
+            _settings.Show();
+            _settings.Activate();
+        }
+
+        private void OnStageChanged(Stage stage)
+        {
+            switch (stage)
+            {
+                case Stage.Recording:
+                    _tray.Icon = _iconRec;
+                    _miToggle.Text = "หยุดพูดแล้วพิมพ์ (" + _hotkey.DisplayString + ")";
+                    break;
+                case Stage.Transcribing:
+                case Stage.Correcting:
+                    _tray.Icon = _iconBusy;
+                    break;
+                default:
+                    _tray.Icon = _iconIdle;
+                    _miToggle.Text = "เริ่มพูด (" + _hotkey.DisplayString + ")";
+                    break;
+            }
+        }
+
+        private void UpdateTexts()
+        {
+            _miToggle.Text = "เริ่มพูด (" + _hotkey.DisplayString + ")";
+            _miCorrection.Checked = _cfg.UseCorrection;
+            _miAutostart.Checked = Autostart.IsEnabled();
+            _miLangTh.Checked = _cfg.Language == "th";
+            _miLangEn.Checked = _cfg.Language == "en";
+            _miLangAuto.Checked = _cfg.Language == "auto";
+
+            var tip = "WhisperApp — กด " + _hotkey.DisplayString + (_cfg.HotkeyHoldMode ? " ค้างเพื่อพูด" : " เพื่อเริ่ม/หยุด");
+            _tray.Text = tip.Length > 63 ? tip.Substring(0, 63) : tip;
+        }
+
+        private void ExitApp()
+        {
+            _tray.Visible = false;
+            _hotkey.Uninstall();
+            ExitThread();
+        }
+    }
+
+    /// Runtime-drawn microphone tray icons (no .ico asset needed).
+    public static class TrayIcons
+    {
+        public static Icon Make(Color color)
+        {
+            using (var bmp = new Bitmap(32, 32))
+            using (var g = Graphics.FromImage(bmp))
+            {
+                g.SmoothingMode = SmoothingMode.AntiAlias;
+                g.Clear(Color.Transparent);
+
+                using (var b = new SolidBrush(color))
+                using (var pen = new Pen(color, 3f))
+                {
+                    // mic capsule
+                    using (var path = new GraphicsPath())
+                    {
+                        path.AddArc(11, 3, 10, 10, 180, 180);
+                        path.AddArc(11, 10, 10, 10, 0, 180);
+                        path.CloseFigure();
+                        g.FillPath(b, path);
+                    }
+                    // pickup arc
+                    g.DrawArc(pen, 7, 8, 18, 16, 20, 140);
+                    // stem + base
+                    g.DrawLine(pen, 16, 24, 16, 28);
+                    g.DrawLine(pen, 10, 29, 22, 29);
+                }
+
+                var hIcon = bmp.GetHicon();
+                using (var tmp = Icon.FromHandle(hIcon))
+                {
+                    return (Icon)tmp.Clone();
+                }
+            }
+        }
+    }
+
+    /// Start-with-Windows via HKCU Run key.
+    public static class Autostart
+    {
+        private const string RunKey = "Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+        private const string Name = "WhisperApp";
+
+        public static bool IsEnabled()
+        {
+            try
+            {
+                using (var rk = Registry.CurrentUser.OpenSubKey(RunKey))
+                {
+                    return rk != null && rk.GetValue(Name) != null;
+                }
+            }
+            catch { return false; }
+        }
+
+        public static void Set(bool on)
+        {
+            try
+            {
+                using (var rk = Registry.CurrentUser.OpenSubKey(RunKey, true))
+                {
+                    if (rk == null) return;
+                    if (on) rk.SetValue(Name, "\"" + Application.ExecutablePath + "\"");
+                    else rk.DeleteValue(Name, false);
+                }
+            }
+            catch (Exception ex) { Log.Error("Autostart: " + ex.Message); }
+        }
+    }
+}


### PR DESCRIPTION
## What

Native **Windows port** of WhisperApp under `windows/` — the same press-hotkey → speak → STT → LLM cleanup → auto-paste flow as the macOS app, implemented as a WinForms system-tray app (Wispr Flow-style dictation).

## How it maps to the macOS code

| macOS (Swift) | Windows (C#) |
|---|---|
| `AudioRecorder.swift` — AVAudioEngine 16 kHz mono tap | `AudioRecorder.cs` — winmm `waveIn` → 16 kHz mono WAV + live RMS level |
| `HotkeyManager.swift` — NSEvent monitors, Fn hold/double-tap | `HotkeyManager.cs` — low-level keyboard hook, default **hold F9**, hold/toggle modes |
| `CloudTranscriptionService.swift` | `SttClient.cs` — same providers, endpoints, multipart fields (`model`/`model_id`, ISO 639-1/-3) |
| `TextCorrectionService.swift` | `LlmClient.cs` — same system prompt, OpenAI + Anthropic request styles, GLM thinking disabled |
| `WhisperService.swift` — local whisper.cpp | `LocalWhisper.cs` — `whisper-cli.exe`, models in `%USERPROFILE%\.whisper-models`, same model-priority pick |
| `Paster` — CGEvent ⌘V | `Paster.cs` — clipboard + `SendInput` Ctrl+V (text stays in clipboard as fallback) |
| `FloatingStatusView.swift` — SwiftUI status pill | `Overlay.cs` — borderless no-activate topmost pill with waveform |
| UserDefaults + `~/.whisperapp` key files | `%APPDATA%\WhisperApp\config.json`; env-var fallback for every provider key preserved |

`stripSoundAnnotations` (removes `(เสียงลม)` / `[applause]` etc.) ported as-is in `TextCleaner.cs`.

## Notable platform differences

- Default hotkey is **F9** — Windows does not expose the Fn key to applications
- Toggle mode needs no double-tap guard: the hook swallows the hotkey so it never leaks into the focused app
- No Accessibility permission dance — `SendInput` works out of the box (except into elevated apps, noted in README)

## Build / run

No SDK, no NuGet: .NET Framework 4.8 (in-box on Win 10/11) compiled with Roslyn csc from VS 2019 Build Tools.
`windows\build.bat` → single self-contained `WhisperApp.exe` · `windows\run.bat` builds + launches · Thai user guide in `windows/README.md`.

## Tested

- Clean build on Windows 10 (19045)
- `WhisperApp.exe --selftest`: config JSON round-trip OK, providers registered (4 STT / 8 LLM), 0.5 s mic capture → valid 16 kHz WAV
- Tray app launches, stays resident (~36 MB), first-run opens Settings when no key is configured, exits cleanly
- ⚠️ Not yet exercised end-to-end against live STT/LLM APIs — needs an API key entered in Settings on the test machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)
